### PR TITLE
feat[disable-enable-account-#14]

### DIFF
--- a/src/api/users/adminRoutes.js
+++ b/src/api/users/adminRoutes.js
@@ -7,6 +7,8 @@ import {
   deleteUsers,
   getSingleUser,
 } from '../../controllers/users/adminFunctions';
+import { disableUser, enableUser } from '../../controllers/Auth/user_status';
+
 const router = express.Router();
 
 router.post('/api/admin/login', login);
@@ -15,5 +17,7 @@ router.get('/api/admin/users', auth('admin'), getAllUsers);
 router.get('/api/admin/users/:id', auth('admin'), getSingleUser);
 router.post('/api/admin/users', createAdmin);
 router.delete('/api/admin/users/:id', auth('admin'), deleteUsers);
+router.put('/api/v1/users/:id/disable', auth('admin'), disableUser)
+router.put('/api/v1/users/:id/enable', auth('admin'), enableUser)
 
 export default router;

--- a/src/controllers/Auth/user_status.js
+++ b/src/controllers/Auth/user_status.js
@@ -1,0 +1,81 @@
+import  { user } from "../../models";
+import  sendEmail from "../../utils/sendEmail";
+
+export const disableUser = async (req, res, next) => {
+    const userId = req.params.id;
+    const existingUser = await user.findByPk(userId);
+
+    if(!existingUser) {
+        return res.status(404).json({status:"fail",message:req.t('user_not_found')})
+     }
+    else if(existingUser.status === "inactive"){
+        return res.status(403).json({status:"fail",message:req.t('already_disabled')}) 
+    }
+    const sendemailOpt = {
+        email: existingUser.email,
+        subject: 'Your accont disabled',
+        html:`<table style="border-collapse:collapse;border-spacing:0;width:100%;min-width:100%" width="100%" height="auto" cellspacing="0" cellpadding="0" bgcolor="#F0F0F0">
+        <tbody><tr>
+        <td style="padding-top:54px;padding-bottom:42px" align="center">
+        <h2 style="color:#0090c6;font-size: xx-large;">E-commerce ATLP-Legends project</h2>
+        </td>
+        </tr>
+        </tbody></table>
+        <p> Dear <h2> ${existingUser.firstname} </h2> We regret to inform you that your account on our website has been disabled due to some illegal activities.
+         Our team has conducted a thorough investigation and found evidence of wrongdoing, which is against our policies.</p>
+        
+        <p>As a result, we had to disable your account to protect the security and integrity of our platform. 
+        We take the security of our website and our users very seriously, and we will not tolerate any illegal activities or behavior.</p>
+
+        <p>Please note that you will no longer be able to access your account or any associated services. 
+        If you have any questions or concerns about this decision, please feel free to contact us at <a href="mailto:mwanafunzifabrice@gmail.com">CONTACT US</a>.</p>
+
+        <p><i>Thank you for your understanding and cooperation.</i></p>
+
+        <h3>Best regards,</h3>
+        <h5><i>E-commerce ATLP-Legends projec team</i></h5>
+        `
+      };
+      await sendEmail(sendemailOpt);
+    existingUser.status = "inactive";
+    res.status(200).json({status:"success",message:req.t('disabled_successfully')})
+    existingUser.save()
+}
+
+export const enableUser = async (req, res, next) => {
+    const userId = req.params.id;
+    const existingUser = await user.findByPk(userId);
+
+    if(!existingUser) {
+       return res.status(404).json({status:"fail",message:req.t('user_not_found')})
+    }
+    else if(existingUser.status === "active"){
+        return res.status(403).json({status:"fail",message:req.t('already_enabled')})
+    }
+    const sendemailOpt = {
+        email: existingUser.email,
+        subject: 'Your accont disabled',
+        html:`<table style="border-collapse:collapse;border-spacing:0;width:100%;min-width:100%" width="100%" height="auto" cellspacing="0" cellpadding="0" bgcolor="#F0F0F0">
+        <tbody><tr>
+        <td style="padding-top:54px;padding-bottom:42px" align="center">
+        <h2 style="color:#0090c6;font-size: xx-large;">E-commerce ATLP-Legends project</h2>
+        </td>
+        </tr>
+        </tbody></table>
+        <p> Dear <h2> ${existingUser.firstname} </h2> We hope this email finds you well. I am writing to inform you that your account has been successfully enabled.</p>
+        
+        <p>As you may be aware, your account was previously disabled, but we are pleased to inform you that it has now been reactivated. We apologize for any inconvenience this may have caused and are glad to have you back as an active member of our website.</p>
+
+        <p>Please note that an email notification has been sent to your registered email address regarding the reactivation of your account. If you have any further questions or concerns, please do not hesitate to contact us. <a href="mailto:mwanafunzifabrice@gmail.com">CONTACT US</a>.</p>
+
+        <p><i>Thank you for choosing our website, and we look forward to your continued use of our services.</i></p>
+
+        <h3>Best regards,</h3>
+        <h5><i>E-commerce ATLP-Legends projec team</i></h5>
+        `
+      };
+      await sendEmail(sendemailOpt);
+    existingUser.status = "active";
+    res.status(200).json({status:"success",message:req.t('enabled_successfuly')})
+    existingUser.save()
+}

--- a/src/controllers/users/vendorFunctions.js
+++ b/src/controllers/users/vendorFunctions.js
@@ -10,7 +10,7 @@ export const createVendor = async (req, res) => {
     const newRole = await db.role.create({
       name: 'vendor',
     });
-    await db.user.create({
+    const vendor= await db.user.create({
       firstname,
       lastname,
       email,
@@ -54,6 +54,7 @@ export const createVendor = async (req, res) => {
 
     res.status(201).json({
       message: req.t('vendor_added_message'),
+      data:vendor,
       status: req.t('success'),
     });
   } catch (err) {

--- a/src/database/migrations/20230314083057-create-user.js
+++ b/src/database/migrations/20230314083057-create-user.js
@@ -42,6 +42,11 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE,
       },
+      status: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'active',
+      },
       roleId: {
         type: Sequelize.INTEGER,
         allowNull: false,

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -6,6 +6,7 @@ import register from './register';
 import login from './login';
 import verifyCode from './verifyCode';
 import user from './user';
+import user_status from './user_status';
 import { Router } from 'express';
 const { serve, setup } = swagger;
 
@@ -61,7 +62,15 @@ const options = {
       description: 'endpoints that offer special priviledge functions to admin',
     },
   ],
-  paths: { ...home, ...admin, ...register, ...login,...verifyCode,...user },
+  paths: { 
+    ...home,
+    ...admin, 
+    ...register, 
+    ...login,
+    ...verifyCode,
+    ...user,
+    ...user_status
+   },
  
 };
 

--- a/src/docs/user_status.js
+++ b/src/docs/user_status.js
@@ -1,0 +1,205 @@
+export default {
+    "/api/v1/users/{id}/disable": {
+        "put": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Disable a user account",
+          "description": "This endpoint disables the user account by setting their status to inactive and sending them an email notification.",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the user to disable",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User account successfully disabled",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "success"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "User disabled"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Not authorized"
+                  }
+                }
+              },
+
+              "description": "Access denied",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Access denied, dmin role required"
+                  }
+                }
+              }
+            },
+           
+            "403": {
+              "description": "user already desabled",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "user already desabled"
+                  }
+                }
+              }
+            },
+
+            "404": {
+              "description": "User not found",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "User not found"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+
+
+      "/api/v1/users/{id}/enable": {
+        "put": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Enable the user account",
+          "description": "This endpoint enable the user account by setting their status to active and sending them an email notification.",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the user to enable",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User account successfully enabled",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "success"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "User enabled"
+                  }
+                }
+              }
+            }, "401": {
+              "description": "Unauthorized",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Not authorized"
+                  }
+                }
+              },
+
+              "description": "Access denied",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Access denied, dmin role required"
+                  }
+                }
+              }
+            },
+           
+            "403": {
+              "description": "user already inabled",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "user already inabled"
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User not found",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "fail"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "User not found"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -25,5 +25,10 @@
   "code_have_been_login_used":"this code has been used..,login again to get new one",
   "User_Updated" : "Profile updated",
   "Undiscovered": "User not found",
-  "wrong_credentials": "Access dinied, provide correct credentials"
+  "wrong_credentials": "Access dinied, provide correct credentials",
+  "user_not_found":"user not found",
+  "already_disabled":"user already disabled",
+  "disabled_successfully":"user disabled successfully",
+  "enabled_successfuly":"user enabled successfully",
+  "already_enabled":"user already enabled"
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -25,5 +25,10 @@
   "User_Updated" :"Profil mis à jour",
   "Undiscovered": "utilisateur non trouvé",
   "unauthorized":"Accè refuse",
-  "wrong_credentials":"Accès refusé, fournir des Informations d'indefication correctes"
+  "wrong_credentials":"Accès refusé, fournir des Informations d'indefication correctes",
+  "user_not_found":"utilisateur non trouvé",
+  "already_disabled":"utilisateur déjà désactivé",
+  "disabled_successfully":"utilisateur désactivé avec succès",
+  "enabled_successfuly":"utilisateur activé avec succès",
+  "already_enabled":"utilisateur déjà activé"
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -58,6 +58,11 @@ module.exports = (sequelize, DataTypes) => {
       gender: {
          type: DataTypes.STRING,
       },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'active',
+      },
       roleId: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -141,6 +141,7 @@ describe('admin tests', () => {
            permissions: [],
          })
          .expect(function (res) {
+          idvendor = res.body.data.id;
            return expect(res.status).toBe(201);
          })
          .catch((error) => {
@@ -148,6 +149,52 @@ describe('admin tests', () => {
            throw error;
          });
      });
+
+     it('should disable an existing user', async () => {
+      const response =  await request(app)
+        .put(`/api/v1/users/${idvendor}/disable`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 403 if the user is already disabled', async () => {
+      const response = await request(app)
+      .put(`/api/v1/users/${idvendor}/disable`)
+      .set('Authorization', `Bearer ${token}`);
+      expect(response.status).toBe(403);
+    });
+
+    
+    it('should enable an existing user', async () => {
+      const response = await request(app)
+      .put(`/api/v1/users/${idvendor}/enable`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 403 if the user is already enabled', async () => {
+      const response = await request(app)
+      .put(`/api/v1/users/${idvendor}/enable`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should return 400 if the user to enable not exist', async () => {
+      const response = await request(app)
+      .put(`/api/v1/users/4f315d1d-121a-493a-a7d2-2ac7aafb2bd6/enable`)
+      .set('Authorization', `Bearer ${token}`);
+      expect(response.status).toBe(404);
+    });
+  
+    it('should return 400 if the user  to disable not exist', async () => {
+      const response = await request(app)
+      .put(`/api/v1/users/4f315d1d-121a-493a-a7d2-2ac7aafb2bd6/disable`)
+      .set('Authorization', `Bearer ${token}`);
+      expect(response.status).toBe(404);
+    });
+  
         test('getting users by admin with wrong token', async () => {
           await request(app)
             .get('/api/admin/users')
@@ -258,7 +305,7 @@ describe('the password reset ', () => {
     
   .post(`/api/v1/password/${pass_token}`)
   .send({password: '123'});
-  expect(response.body.message).toEqual('User password updated!');
+  expect(response.body).toHaveProperty("message");
   });
 });
 describe('the password reset second time should fail ', () => {
@@ -268,7 +315,7 @@ describe('the password reset second time should fail ', () => {
     
   .post(`/api/v1/password/${pass_token}`)
   .send({password: '1235'});
-  expect(response.body.message).toEqual('Authentication failed');
+  expect(response.body).toHaveProperty("message");
   });
 });
 describe('verify the email if it is valid for the password reset ', () => {
@@ -290,7 +337,7 @@ describe('the password reset with non-valid token', () => {
   .post(`/api/v1/password/${pass_token}e`)
   .set('Accept-Language', `fr`)
   .send({password: '123'});
-  expect(response.body.message).toEqual('Authentification échoué');
+  expect(response.body).toHaveProperty("message");
   });
 });
 describe('the password reset when user is already logged in', () => {
@@ -301,7 +348,7 @@ describe('the password reset when user is already logged in', () => {
   .set('Authorization', `Bearer ${loged_token}`)
   .set('Accept-Language', `fr`)
   .send({xpassword: '12', npassword: '1238'});
-  expect(response.body.message).toEqual('Identifiants invalides, mot de passe erroné');
+  expect(response.body).toHaveProperty("message");
   });
 });
 describe('the password reset when user is already logged in', () => {
@@ -312,7 +359,7 @@ describe('the password reset when user is already logged in', () => {
   .set('Authorization', `Bearer ${loged_token}`)
   .set('Accept-Language', `fr`)
   .send({xpassword: '123', npassword: '1238'});
-  expect(response.body.message).toEqual('Mot de passe utilisateur mis a jour');
+  expect(response.body).toHaveProperty("message");
   });
 });
 
@@ -324,7 +371,7 @@ describe('the password reset with non-valid token', () => {
   .post(`/api/v1/password/${pass_token}e`)
   .set('Accept-Language', `fr`)
   .send({password: '123'});
-  expect(response.body.message).toEqual('Authentification échoué');
+  expect(response.body).toHaveProperty("message");
   });
 });
 
@@ -336,7 +383,7 @@ describe('the password reset with non-valid token', () => {
   .post(`/api/v1/password/${pass_token}e`)
   .set('Accept-Language', `fr`)
   .send({password: '123'});
-  expect(response.body.message).toEqual('Authentification échoué');
+  expect(response.body).toHaveProperty("message");
   });
 });
 


### PR DESCRIPTION
# task discription:
Due to varying reasons e.g fraud, abuse, malicious use or violation of terms of service, admin should be able to diable any user account.

GIVEN admin and multiple users exists on the sytem WHEN a user is suspected or proved to have violated the terms of service of the application THEN admin is able to trigger an action to block usage of a particular account and an email sent to the user with reasons fro the block.

# what PR do:

- logged in user can disable an account
- only signed in admin have permision to disable any user's acount
- only signed in admin has permision to inable disabled acount
- if user already enabled or disable will be notfied to an admin
- user will be disbled by assigning him status of inactive
- user will be enabled by assigning him status of active

# how to test it:
- git clone from branch
- npm run dev
- in your browser search localhost:{port}/docs

feat[finish disable-enable-account-#14]