### PR TITLE
#38 feature for clearing cart

### DIFF
--- a/src/controllers/shoppingCartController/addToCartController.js
+++ b/src/controllers/shoppingCartController/addToCartController.js
@@ -119,13 +119,13 @@ export const viewCart = asyncWrapper(async (req, res) => {
   if (!cart) {
     res.status(404).json({
       status: req.t('fail'),
-      message: "No Product found in Cart"
+      message: req.t('cart_already_empty'),
     })
   }
 
   res.status(200).json({
     status: req.t('success'),
-    message: req.t('The cart has been retrieved successful!'),
+    message: req.t('cart_retrieved'),
     data: cart,
 
   })

--- a/src/controllers/shoppingCartController/clearCartController.js
+++ b/src/controllers/shoppingCartController/clearCartController.js
@@ -1,0 +1,31 @@
+import db from '../../database/models';
+import { asyncWrapper } from '../../utils/handlingTryCatchBlocks';
+
+export const clearCart = asyncWrapper(async (req, res) => {
+    const buyerId = req.user.id;
+    const cartItems =  await db.shoppingCarts.destroy({
+        where: {
+          buyer: buyerId,
+          cartStatus: 'active'
+        }
+      });
+
+      const totalPrice =  await db.shoppingCarts.findAll({
+        where: {
+          buyer: buyerId
+        }
+      });
+    
+      if (cartItems === 0) {
+        return res.status(200).json({
+          status: req.t('success'),
+          message: req.t('cart_already_empty')
+        });
+      }
+
+    return res.status(200).json({
+    status: req.t('success'),
+    message: req.t('cart_cleared'),
+    data: req.t('total_price', { totalAmount: totalPrice.length }),
+  });
+  });

--- a/src/docs/Cart.js
+++ b/src/docs/Cart.js
@@ -116,7 +116,7 @@ export default {
               $ref: '#/components/schemas/shoppingCart',
             },
             example: {
-              id: '1'
+              id: '1',
             },
           },
         },
@@ -133,6 +133,46 @@ export default {
         },
         500: {
           description: 'Internal Server Error',
+        },
+      },
+    },
+  },
+
+  '/api/v1/shoppingCart/clear': {
+    delete: {
+      tags: ['Shopping Cart'],
+      summary: "Clear the buyer's shopping cart",
+      description:
+        "Clears all the items from the buyer's shopping cart and resets the cart total to zero.",
+      security: [
+        {
+          bearerAuth: [],
+        },
+      ],
+      responses: {
+        200: {
+          description: 'Success',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string',
+                    description: 'Success status message',
+                  },
+                  data: {
+                    type: 'string',
+                    description: 'Total price of the cart',
+                  },
+                  message: {
+                    type: 'string',
+                    description: 'Success message',
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -64,5 +64,9 @@
   "ColorbeenAddtoCart":"has been added",
   "cart_item_updated":"cart item updated successfully",
   "cart_item_deleted":"cart item deleted successfully",
-  "exceeds_stock":"quantity you want exceeds our stock"
+  "exceeds_stock":"quantity you want exceeds our stock",
+  "cart_cleared": "Cart cleared successfully",
+  "cart_already_empty": "cart is empty",
+  "total_price": "Total Amount: {{totalAmount}}",
+  "cart_retrieved": "Cart retrieved successfully"
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -65,5 +65,9 @@
   "The cart has been retrieved successful!": "Le panier a été récupéré avec succès!",
     "cart_item_updated":"article du panier mis à jour avec succès",
   "cart_item_deleted":"article du panier supprimé avec succès",
-  "exceeds_stock":"La quantité demandée dépasse la quantité en stock"
+  "exceeds_stock":"La quantité demandée dépasse la quantité en stock",
+  "cart_cleared": "Panier vidé avec succès",
+  "cart_already_empty": "Le panier est vide",
+  "total_price": "Montant total : {{totalAmount}}",
+  "cart_retrieved": "Le panier a été récupéré avec succès!"
 }

--- a/src/routes/shoppingCart/shoppingCartRoutes.js
+++ b/src/routes/shoppingCart/shoppingCartRoutes.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import { auth } from '../../middleware/auth';
+import { clearCart } from '../../controllers/shoppingCartController/clearCartController';
+import { isUserEnabled } from '../../middleware/auth';
 import {
   addToCart,
   viewCart,
@@ -12,22 +14,32 @@ const CartRoutes = express.Router();
 CartRoutes.post(
   '/api/v1/shoppingCart/add',
   auth(['vendor', 'buyer', 'admin']),
+  isUserEnabled,
   addToCart
 );
 CartRoutes.get(
   '/api/v1/shoppingCart/view',
   auth(['vendor', 'buyer', 'admin']),
+  isUserEnabled,
   viewCart
 );
 CartRoutes.patch(
   '/api/v1/shoppingCart/update',
   auth(['vendor', 'buyer', 'admin']),
+  isUserEnabled,
   updateCart
 );
 CartRoutes.delete(
   '/api/v1/shoppingCart/delete',
   auth(['vendor', 'buyer', 'admin']),
+  isUserEnabled,
   deleteCartItem
+);
+CartRoutes.delete(
+  '/api/v1/shoppingCart/clear',
+  auth(['vendor', 'buyer', 'admin']),
+  isUserEnabled,
+  clearCart
 );
 
 export default CartRoutes;


### PR DESCRIPTION
### what does this pr do:

emptying the cart in the buyer's session and resetting the cart total to zero.

#### Description of Task to be completed?

- have this endpoint working:
- DELETE /api/v1/shoppingCart/clear


#### How should this be manually tested?

- `git clone` from repo
- run `npm i`
- run `npm run dev`
- with postman use the above route to clear cart
- with swagger doc search `localhost:{port}/docs`